### PR TITLE
Add translations for new locales

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">اضغط على البدء</string>
+    <string name="app_description">اضبط موسيقاك على التوقف بعد أن تغفو</string>
+</resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">শুরু করতে আলতো চাপুন</string>
+    <string name="app_description">আপনি ঘুমিয়ে পড়ার পরে আপনার সংগীত বন্ধ করুন</string>
+</resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">Toque para comenzar</string>
+    <string name="app_description">Pon tu música para que se detenga después de que te duermas</string>
+</resources>

--- a/app/src/main/res/values-fi-rPH/strings.xml
+++ b/app/src/main/res/values-fi-rPH/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">Napauta aloittaaksesi</string>
+    <string name="app_description">Aseta musiikkisi pysähtymään, kun nukahdat</string>
+</resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">Mag-tap upang magsimula</string>
+    <string name="app_description">Itakda ang iyong musika upang ihinto pagkatapos mong makatulog</string>
+</resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">시작하려면 탭합니다</string>
+    <string name="app_description">잠든 후 음악이 멈추도록 설정하세요.</string>
+</resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">شروع کرنے کے لئے ٹیپ کریں</string>
+    <string name="app_description">اپنی موسیقی کو آپ کے سو جانے کے بعد رکنے کے لیے سیٹ کریں</string>
+</resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="tile_subtitle">Nhấn để bắt đầu</string>
+    <string name="app_description">Đặt nhạc của bạn dừng lại sau khi bạn ngủ thiếp đi</string>
+</resources>


### PR DESCRIPTION
## Summary
- add Arabic (Egypt), Bengali (Bangladesh), Spanish (Mexico), Filipino, Korean, Urdu, Vietnamese, and Finnish (Philippines) translations

## Testing
- `bash ./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510149c33c832d941165bf56635e75