### PR TITLE
Update changelog for 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Version 3.0.5:
 
-- **Minor**: Updated Android Gradle Plugin (AGP) to 8.10.1.
-- **Minor**: Updated AppCompat to 1.7.1.
-- **Minor**: Updated Firebase BoM to 33.15.0.
-- **Minor**: Updated Kotlin to 2.1.21.
-- **Minor**: Updated Google Firebase Crashlytics to 3.0.4.
-- **Minor**: Updated Gradle Wrapper to 8.14.2-bin.
-- **Minor**: Updated target SDK to 36.
-- **Minor**: Added various Google Analytics metadata tags to `AndroidManifest.xml`.
+- Added new translations so the app now speaks Arabic (Egypt), Bengali (Bangladesh), Spanish (Mexico), Filipino (Philippines), Korean (South Korea), Urdu (Pakistan), and Vietnamese (Vietnam).
+- Removed the outdated Finnish (Philippines) translation.
+- Updated our build tools and libraries to keep everything running smoothly on Android 14 (target SDK 36).
+- Improved our analytics setup for better crash reporting.
 
 # Version 3.0.4:
 


### PR DESCRIPTION
## Summary
- simplify release notes for 3.0.5

## Testing
- `bash gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511cb15a6c832daeea6de98ddba76b